### PR TITLE
Add custom phone-based user model

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -1,0 +1,29 @@
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+
+from .forms import UserCreationForm, UserChangeForm
+from .models import User
+
+
+class UserAdmin(BaseUserAdmin):
+    form = UserChangeForm
+    add_form = UserCreationForm
+    list_display = ('phone', 'is_staff')
+    list_filter = ('is_staff', 'is_superuser', 'is_active')
+    fieldsets = (
+        (None, {'fields': ('phone', 'password')}),
+        ('Permissions', {'fields': ('is_active', 'is_staff', 'is_superuser')}),
+        ('Important dates', {'fields': ('last_login',)}),
+    )
+    add_fieldsets = (
+        (None, {
+            'classes': ('wide',),
+            'fields': ('phone', 'password1', 'password2'),
+        }),
+    )
+    search_fields = ('phone',)
+    ordering = ('phone',)
+    filter_horizontal = ()
+
+
+admin.site.register(User, UserAdmin)

--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AccountsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'accounts'

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,0 +1,38 @@
+from django import forms
+from django.contrib.auth.forms import ReadOnlyPasswordHashField
+
+from .models import User
+
+
+class UserCreationForm(forms.ModelForm):
+    password1 = forms.CharField(label='Password', widget=forms.PasswordInput)
+    password2 = forms.CharField(label='Password confirmation', widget=forms.PasswordInput)
+
+    class Meta:
+        model = User
+        fields = ('phone',)
+
+    def clean_password2(self):
+        password1 = self.cleaned_data.get('password1')
+        password2 = self.cleaned_data.get('password2')
+        if password1 and password2 and password1 != password2:
+            raise forms.ValidationError("Passwords don't match")
+        return password2
+
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        user.set_password(self.cleaned_data['password1'])
+        if commit:
+            user.save()
+        return user
+
+
+class UserChangeForm(forms.ModelForm):
+    password = ReadOnlyPasswordHashField()
+
+    class Meta:
+        model = User
+        fields = ('phone', 'password', 'is_active', 'is_staff')
+
+    def clean_password(self):
+        return self.initial['password']

--- a/accounts/managers.py
+++ b/accounts/managers.py
@@ -1,0 +1,26 @@
+from django.contrib.auth.base_user import BaseUserManager
+from django.utils.translation import gettext_lazy as _
+
+
+class UserManager(BaseUserManager):
+    """Custom user manager where phone number is the unique identifiers"""
+
+    def create_user(self, phone, password=None, **extra_fields):
+        if not phone:
+            raise ValueError(_('The Phone number must be set'))
+        user = self.model(phone=phone, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_superuser(self, phone, password=None, **extra_fields):
+        extra_fields.setdefault('is_staff', True)
+        extra_fields.setdefault('is_superuser', True)
+        extra_fields.setdefault('is_active', True)
+
+        if extra_fields.get('is_staff') is not True:
+            raise ValueError(_('Superuser must have is_staff=True.'))
+        if extra_fields.get('is_superuser') is not True:
+            raise ValueError(_('Superuser must have is_superuser=True.'))
+
+        return self.create_user(phone, password, **extra_fields)

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,0 +1,21 @@
+from django.contrib.auth.models import AbstractBaseUser
+from django.db import models
+from django.utils import timezone
+
+from .managers import UserManager
+
+
+class User(AbstractBaseUser):
+    phone = models.CharField(max_length=15, unique=True)
+    is_staff = models.BooleanField(default=False)
+    is_superuser = models.BooleanField(default=False)
+    is_active = models.BooleanField(default=True)
+    date_joined = models.DateTimeField(default=timezone.now)
+
+    objects = UserManager()
+
+    USERNAME_FIELD = 'phone'
+    REQUIRED_FIELDS = []
+
+    def __str__(self):
+        return self.phone

--- a/config/settings.py
+++ b/config/settings.py
@@ -24,6 +24,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'accounts.apps.AccountsConfig',
 ]
 
 MIDDLEWARE = [
@@ -98,5 +99,7 @@ USE_I18N = True
 USE_TZ = True
 
 STATIC_URL = os.getenv("STATIC_URL", "static/")
+
+AUTH_USER_MODEL = 'accounts.User'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'


### PR DESCRIPTION
## Summary
- create `accounts` Django app
- implement custom `User` model with phone as username
- register new model in admin with custom forms
- configure project to use new `accounts` app and custom user model
- remove built-in permission fields for custom implementation

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f6c4372a88330871417b559e71758