### PR TITLE
Add Sphinx docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # testcodex
+
+This repository contains a sample Django project. Documentation is generated with **Sphinx** in the `docs/` directory.
+
+To build the documentation run:
+
+```bash
+sphinx-build -b html docs docs/_build
+```
+
+The resulting HTML files will be placed in `docs/_build`.

--- a/access_control/services.py
+++ b/access_control/services.py
@@ -1,16 +1,20 @@
 from django.shortcuts import get_object_or_404
 
+"""Helper functions for managing permissions and roles."""
+
 from . import models
 
 
 # Permission CRUD
 
 def create_permission(*, codename, name):
+    """Create a new permission with the given codename and name."""
     permission = models.Permission.objects.create(codename=codename, name=name)
     return permission
 
 
 def update_permission(*, permission, codename=None, name=None):
+    """Update fields of ``permission`` and return it."""
     if codename is not None:
         permission.codename = codename
     if name is not None:
@@ -20,17 +24,20 @@ def update_permission(*, permission, codename=None, name=None):
 
 
 def delete_permission(*, permission):
+    """Remove the given permission from the database."""
     permission.delete()
 
 
 # Role CRUD
 
 def create_role(*, name):
+    """Create a new role with the given name."""
     role = models.Role.objects.create(name=name)
     return role
 
 
 def update_role(*, role, name=None):
+    """Update ``role`` with a new ``name`` if provided."""
     if name is not None:
         role.name = name
     role.save()
@@ -38,22 +45,27 @@ def update_role(*, role, name=None):
 
 
 def delete_role(*, role):
+    """Delete the given role from the database."""
     role.delete()
 
 
 # Assignments
 
 def assign_permission_to_role(*, role, permission):
+    """Attach a permission to a role."""
     role.permissions.add(permission)
 
 
 def remove_permission_from_role(*, role, permission):
+    """Detach a permission from a role."""
     role.permissions.remove(permission)
 
 
 def assign_role_to_user(*, role, user):
+    """Assign ``role`` to ``user``."""
     models.UserRole.objects.get_or_create(role=role, user=user)
 
 
 def remove_role_from_user(*, role, user):
+    """Remove ``role`` from ``user``."""
     models.UserRole.objects.filter(role=role, user=user).delete()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,17 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'testcodex'
+author = 'testcodex'
+release = '0.1'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+html_theme = 'alabaster'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,10 @@
+Welcome to testcodex's documentation!
+=====================================
+
+This documentation provides an overview of the core modules of the **testcodex** project.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,57 @@
+API Reference
+=============
+
+Accounts
+--------
+.. automodule:: accounts.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: accounts.forms
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Access Control
+--------------
+.. automodule:: access_control.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: access_control.services
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+OTP
+---
+.. automodule:: otp.services
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: otp.providers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Profile
+-------
+.. automodule:: profile.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: profile.services
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Activity
+--------
+.. automodule:: activity.services
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/otp/services.py
+++ b/otp/services.py
@@ -1,3 +1,5 @@
+"""Utility functions for OTP authentication."""
+
 import random
 from django.contrib.auth import get_user_model
 
@@ -10,10 +12,12 @@ User = get_user_model()
 
 
 def _generate_code() -> str:
+    """Return a random 6 digit numeric string."""
     return f"{random.randint(100000, 999999)}"
 
 
 def send_otp_code(*, phone: str, provider: BaseOtpProvider | None = None) -> None:
+    """Generate and send an OTP code to the given phone number."""
     code = _generate_code()
     hashed = make_password(code)
     set_otp(phone, hashed)
@@ -22,6 +26,7 @@ def send_otp_code(*, phone: str, provider: BaseOtpProvider | None = None) -> Non
 
 
 def verify_otp_code(*, phone: str, code: str) -> bool:
+    """Validate an OTP code for the given phone number."""
     stored = get_otp(phone)
     if stored and check_password(code, stored):
         delete_otp(phone)
@@ -30,6 +35,7 @@ def verify_otp_code(*, phone: str, code: str) -> bool:
 
 
 def login_or_register(*, phone: str) -> User:
+    """Return an existing user for ``phone`` or create a new one."""
     user, created = User.objects.get_or_create(phone=phone)
     return user
 

--- a/profile/services.py
+++ b/profile/services.py
@@ -1,7 +1,10 @@
+"""Business logic for user profile management."""
+
 from .models import Profile
 
 
 def create_profile(*, user, first_name='', last_name='', bio='', avatar=''):
+    """Create and return a new profile for ``user``."""
     profile = Profile.objects.create(
         user=user,
         first_name=first_name,
@@ -13,6 +16,7 @@ def create_profile(*, user, first_name='', last_name='', bio='', avatar=''):
 
 
 def update_profile(*, profile, first_name=None, last_name=None, bio=None, avatar=None):
+    """Update fields of ``profile`` and return the updated instance."""
     if first_name is not None:
         profile.first_name = first_name
     if last_name is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ djangorestframework-simplejwt
 django-activity-stream
 drf-spectacular
 drf-spectacular-sidecar
+sphinx


### PR DESCRIPTION
## Summary
- add docs directory with Sphinx configuration
- add usage info about documentation in README
- document OTP, profile and access control services
- include Sphinx in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840160d5cbc833081ae268fdef20da0