### PR TITLE
Add default permissions and roles

### DIFF
--- a/access_control/migrations/0002_default_permissions_roles.py
+++ b/access_control/migrations/0002_default_permissions_roles.py
@@ -1,0 +1,79 @@
+from django.db import migrations
+
+
+def create_permissions_and_roles(apps, schema_editor):
+    Permission = apps.get_model('access_control', 'Permission')
+    Role = apps.get_model('access_control', 'Role')
+
+    permission_codenames = [
+        'can_add_permission',
+        'can_change_permission',
+        'can_delete_permission',
+        'can_view_permission',
+        'can_add_role',
+        'can_change_role',
+        'can_delete_role',
+        'can_view_role',
+        'can_assign_permission_to_role',
+        'can_remove_permission_from_role',
+        'can_assign_role_to_user',
+        'can_remove_role_from_user',
+        'can_assign_target_to_user',
+        'can_remove_target_from_user',
+        'can_view_activity',
+        'can_view_activity_target',
+    ]
+
+    permissions = []
+    for codename in permission_codenames:
+        perm, _ = Permission.objects.get_or_create(
+            codename=codename, defaults={'name': codename}
+        )
+        permissions.append(perm)
+
+    roles = {}
+    for role_name in ['admin', 'manager', 'user']:
+        role, _ = Role.objects.get_or_create(name=role_name)
+        roles[role_name] = role
+
+    # Give all permissions to the admin role
+    admin_role = roles['admin']
+    admin_role.permissions.add(*permissions)
+
+
+def remove_permissions_and_roles(apps, schema_editor):
+    Permission = apps.get_model('access_control', 'Permission')
+    Role = apps.get_model('access_control', 'Role')
+    admin_role = Role.objects.filter(name='admin').first()
+    if admin_role:
+        admin_role.permissions.clear()
+    Permission.objects.filter(codename__in=[
+        'can_add_permission',
+        'can_change_permission',
+        'can_delete_permission',
+        'can_view_permission',
+        'can_add_role',
+        'can_change_role',
+        'can_delete_role',
+        'can_view_role',
+        'can_assign_permission_to_role',
+        'can_remove_permission_from_role',
+        'can_assign_role_to_user',
+        'can_remove_role_from_user',
+        'can_assign_target_to_user',
+        'can_remove_target_from_user',
+        'can_view_activity',
+        'can_view_activity_target',
+    ]).delete()
+    Role.objects.filter(name__in=['admin', 'manager', 'user']).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('access_control', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_permissions_and_roles, remove_permissions_and_roles),
+    ]

--- a/access_control/tests/test_default_permissions_roles_migration.py
+++ b/access_control/tests/test_default_permissions_roles_migration.py
@@ -1,0 +1,10 @@
+from django.test import TestCase
+from access_control.models import Role, Permission
+
+
+class DefaultPermissionsRolesMigrationTests(TestCase):
+    def test_admin_role_has_all_permissions(self):
+        admin_role = Role.objects.get(name='admin')
+        all_perms = set(Permission.objects.values_list('codename', flat=True))
+        admin_perms = set(admin_role.permissions.values_list('codename', flat=True))
+        self.assertEqual(admin_perms, all_perms)

--- a/accounts/managers.py
+++ b/accounts/managers.py
@@ -37,4 +37,12 @@ class UserManager(BaseUserManager):
         if extra_fields.get('is_superuser') is not True:
             raise ValueError(_('Superuser must have is_superuser=True.'))
 
-        return self.create_user(phone, password, **extra_fields)
+        user = self.create_user(phone, password, **extra_fields)
+
+        # Assign the admin role to newly created superusers
+        from access_control import models as ac_models
+
+        admin_role, _ = ac_models.Role.objects.get_or_create(name='admin')
+        ac_models.UserRole.objects.get_or_create(user=user, role=admin_role)
+
+        return user

--- a/accounts/tests/test_superuser_admin_role.py
+++ b/accounts/tests/test_superuser_admin_role.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+from accounts.models import User
+from access_control.models import Role, UserRole
+
+
+class SuperuserAdminRoleTests(TestCase):
+    def test_superuser_receives_admin_role(self):
+        user = User.objects.create_superuser(phone='09125555555', password='pass1234')
+        role = Role.objects.get(name='admin')
+        self.assertTrue(UserRole.objects.filter(user=user, role=role).exists())
+


### PR DESCRIPTION
## Summary
- add new migration to populate default permissions & roles
- give admin role all permissions by default
- test admin role has all permissions

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68405ab3fb0c83308b0bed0bb13ff756